### PR TITLE
Add Blake2b support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ As of the last release, the following algorithms are implemented:
 
 **Digests:**
 
+  * Blake2b
   * MD2
   * MD4
   * MD5

--- a/benchmark/digests/blake2b_benchmark.dart
+++ b/benchmark/digests/blake2b_benchmark.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-present, the authors of the Pointy Castle project
+// This library is dually licensed under LGPL 3 and MPL 2.0.
+// See file LICENSE for more information.
+
+library pointycastle.benchmark.digests.blake2b_benchmark;
+
+import "../benchmark/digest_benchmark.dart";
+
+main() {
+  new DigestBenchmark("Blake2b").report();
+}
+

--- a/lib/digests/blake2b.dart
+++ b/lib/digests/blake2b.dart
@@ -1,0 +1,274 @@
+// Copyright (c) 2015-present, the authors of the Pointy Castle project
+// This library is dually licensed under LGPL 3 and MPL 2.0.
+// See file LICENSE for more information.
+
+import "dart:typed_data";
+
+import "package:pointycastle/api.dart";
+import "package:pointycastle/src/ufixnum.dart";
+import "package:pointycastle/src/impl/base_digest.dart";
+import "package:pointycastle/src/registry/registry.dart";
+
+class Blake2bDigest extends BaseDigest implements Digest {
+  static final FactoryConfig FACTORY_CONFIG =
+      new StaticFactoryConfig(Digest, "Blake2b");
+
+  static const _rounds = 12;
+  static const _blockSize = 128;
+
+  int _digestLength = 64;
+  int _keyLength = 0;
+  Uint8List _salt;
+  Uint8List _personalization;
+
+  Uint8List _key;
+
+  Uint8List _buffer;
+  // Position of last inserted byte:
+  int _bufferPos = 0; // a value from 0 up to 128
+  final _internalState = new Register64List(16); // In the Blake2b paper it is called: v
+  Register64List _chainValue; // state vector, in the Blake2b paper it is called: h
+
+  final _t0 = new Register64(); // holds last significant bits, counter (counts bytes)
+  final _t1 = new Register64(); // counter: Length up to 2^128 are supported
+  final _f0 = new Register64(); // finalization flag, for last block: ~0L
+
+  Blake2bDigest(
+      {int digestSize = 64,
+      Uint8List key = null,
+      Uint8List salt = null,
+      Uint8List personalization = null}) {
+    _buffer = new Uint8List(_blockSize);
+
+    if (digestSize < 1 || digestSize > 64) {
+      throw new ArgumentError("Invalid digest length (required: 1 - 64)");
+    }
+    _digestLength = digestSize;
+    if (salt != null) {
+      if (salt.length != 16) throw new ArgumentError("salt length must be exactly 16 bytes");
+      _salt = new Uint8List.fromList(salt);
+    }
+    if (personalization != null) {
+      if (personalization.length != 16)
+        throw new ArgumentError("personalization length must be exactly 16 bytes");
+      _personalization = new Uint8List.fromList(personalization);
+    }
+    if (key != null) {
+      if (key.length > 64) throw new ArgumentError("Keys > 64 are not supported");
+      _key = new Uint8List.fromList(key);
+
+      _keyLength = key.length;
+      _buffer.setAll(0, key);
+      _bufferPos = _blockSize;
+    }
+    init();
+  }
+
+  String get algorithmName => "Blake2b";
+  int get digestSize => _digestLength;
+
+  void init() {
+    if (_chainValue == null) {
+      _chainValue = new Register64List(8);
+      _chainValue[0]
+        ..set(_blake2b_IV[0])
+        ..xor(new Register64(digestSize | (_keyLength << 8) | 0x1010000));
+      _chainValue[1].set(_blake2b_IV[1]);
+      _chainValue[2].set(_blake2b_IV[2]);
+
+      _chainValue[3].set(_blake2b_IV[3]);
+
+      _chainValue[4].set(_blake2b_IV[4]);
+      _chainValue[5].set(_blake2b_IV[5]);
+      if (_salt != null) {
+        _chainValue[4].xor(new Register64()..unpack(_salt, 0, Endianness.LITTLE_ENDIAN));
+        _chainValue[5].xor(new Register64()..unpack(_salt, 8, Endianness.LITTLE_ENDIAN));
+      }
+
+      _chainValue[6].set(_blake2b_IV[6]);
+      _chainValue[7].set(_blake2b_IV[7]);
+      if (_personalization != null) {
+        _chainValue[6].xor(new Register64()..unpack(_personalization, 0, Endianness.LITTLE_ENDIAN));
+        _chainValue[7].xor(new Register64()..unpack(_personalization, 8, Endianness.LITTLE_ENDIAN));
+      }
+    }
+  }
+
+  void _initializeInternalState() {
+    _internalState.setRange(0, _chainValue.length, _chainValue);
+    _internalState.setRange(_chainValue.length, _chainValue.length + 4, _blake2b_IV);
+    _internalState[12]
+      ..set(_t0)
+      ..xor(_blake2b_IV[4]);
+    _internalState[13]
+      ..set(_t1)
+      ..xor(_blake2b_IV[5]);
+    _internalState[14]
+      ..set(_f0)
+      ..xor(_blake2b_IV[6]);
+    _internalState[15]..set(_blake2b_IV[7]); // ^ f1 with f1 = 0
+  }
+
+  void updateByte(int inp) {
+    if (_bufferPos == _blockSize) {
+      // full buffer
+      _t0.sum(_blockSize);
+      // This requires hashing > 2^64 bytes which is impossible for the forseeable future.
+      // So _t1 is untested dead code, but I've left it in because it is in the source library.
+      if (_t0.lo32 == 0 && _t0.hi32 == 0)
+        _t1.sum(1);
+      _compress(_buffer, 0);
+      _buffer.fillRange(0, _buffer.length, 0); // clear buffer
+      _buffer[0] = inp;
+      _bufferPos = 1;
+    } else {
+      _buffer[_bufferPos] = inp;
+      ++_bufferPos;
+    }
+  }
+
+  void update(Uint8List inp, int inpOff, int len) {
+    if(inp == null || len == 0)
+      return;
+
+    int remainingLength = 0;
+    if (_bufferPos != 0) {
+      remainingLength = _blockSize - _bufferPos;
+      if (remainingLength < len) {
+        _buffer.setRange(_bufferPos, _bufferPos + remainingLength, inp, inpOff);
+        _t0.sum(_blockSize);
+        if (_t0.lo32 == 0 && _t0.hi32 == 0)
+          _t1.sum(1);
+        _compress(inp, 0);
+        _bufferPos = 0;
+        _buffer.fillRange(0, _buffer.length, 0); // clear buffer
+      } else {
+        _buffer.setRange(_bufferPos, _bufferPos + len, inp, inpOff);
+        _bufferPos += len;
+        return;
+      }
+    }
+
+    int msgPos;
+    int blockWiseLastPos = inpOff + len - _blockSize;
+    for (msgPos = inpOff + remainingLength; msgPos < blockWiseLastPos; msgPos += _blockSize) {
+      _t0.sum(_blockSize);
+      if (_t0.lo32 == 0 && _t0.hi32 == 0)
+        _t1.sum(1);
+      _compress(inp, msgPos);
+    }
+
+    _buffer.setRange(0, inpOff + len - msgPos, inp, msgPos);
+    _bufferPos += inpOff + len - msgPos;
+  }
+
+  int doFinal(Uint8List out, int outOff) {
+    _f0.set(0xFFFFFFFF, 0xFFFFFFFF);
+    _t0.sum(_bufferPos);
+    if (_bufferPos > 0 && _t0.lo32 == 0 && _t0.hi32 == 0)
+      _t1.sum(1);
+    _compress(_buffer, 0);
+    _buffer.fillRange(0, _buffer.length, 0); // clear buffer
+    _internalState.fillRange(0, _internalState.length, 0);
+
+    final packedValue = new Uint8List(8);
+    final packedValueData = packedValue.buffer.asByteData();
+    for (var i = 0; i < _chainValue.length && (i * 8 < _digestLength); ++i) {
+      _chainValue[i].pack(packedValueData, 0, Endianness.LITTLE_ENDIAN);
+
+      final start = outOff + i * 8;
+      if (i * 8 < _digestLength - 8) {
+        out.setRange(start, start + 8, packedValue);
+      } else {
+        out.setRange(start, start + _digestLength - (i * 8), packedValue);
+      }
+    }
+
+    _chainValue.fillRange(0, _chainValue.length, 0);
+
+    reset();
+
+    return _digestLength;
+  }
+
+  void reset() {
+    _bufferPos = 0;
+    _f0.set(0);
+    _t0.set(0);
+    _t1.set(0);
+    _chainValue = null;
+    _buffer.fillRange(0, _buffer.length, 0);
+    if (_key != null) {
+      _buffer.setAll(0, _key);
+      _bufferPos = _blockSize;
+    }
+    init();
+  }
+
+  // This variable is faster as a class member.
+  final _m = new Register64List(16);
+  void _compress(Uint8List message, int messagePos) {
+    _initializeInternalState();
+
+    for (var j = 0; j < 16; ++j) {
+      _m[j].unpack(message, messagePos + j * 8, Endianness.LITTLE_ENDIAN);
+    }
+
+    for (var round = 0; round < _rounds; ++round) {
+      G(_m[_blake2b_sigma[round][0]], _m[_blake2b_sigma[round][1]], 0, 4, 8, 12);
+      G(_m[_blake2b_sigma[round][2]], _m[_blake2b_sigma[round][3]], 1, 5, 9, 13);
+      G(_m[_blake2b_sigma[round][4]], _m[_blake2b_sigma[round][5]], 2, 6, 10, 14);
+      G(_m[_blake2b_sigma[round][6]], _m[_blake2b_sigma[round][7]], 3, 7, 11, 15);
+      G(_m[_blake2b_sigma[round][8]], _m[_blake2b_sigma[round][9]], 0, 5, 10, 15);
+      G(_m[_blake2b_sigma[round][10]], _m[_blake2b_sigma[round][11]], 1, 6, 11, 12);
+      G(_m[_blake2b_sigma[round][12]], _m[_blake2b_sigma[round][13]], 2, 7, 8, 13);
+      G(_m[_blake2b_sigma[round][14]], _m[_blake2b_sigma[round][15]], 3, 4, 9, 14);
+    }
+
+    for (var offset = 0; offset < _chainValue.length; ++offset) {
+      _chainValue[offset]..xor(_internalState[offset])..xor(_internalState[offset + 8]);
+    }
+  }
+
+  void G(Register64 m1, Register64 m2, int posA, int posB, int posC, int posD) {
+    // This variable is faster as a local. The allocation is probably sunk.
+    final r = new Register64();
+
+    _internalState[posA].sumReg(r..set(_internalState[posB])..sumReg(m1));
+    _internalState[posD]..xor(_internalState[posA])..rotr(32);
+    _internalState[posC].sumReg(_internalState[posD]);
+    _internalState[posB]..xor(_internalState[posC])..rotr(24);
+    _internalState[posA].sumReg(r..set(_internalState[posB])..sumReg(m2));
+    _internalState[posD]..xor(_internalState[posA])..rotr(16);
+    _internalState[posC].sumReg(_internalState[posD]);
+    _internalState[posB]..xor(_internalState[posC])..rotr(63);
+  }
+}
+
+// Produced from the square root of primes 2, 3, 5, 7, 11, 13, 17, 19.
+// The same as SHA-512 IV.
+final _blake2b_IV = new Register64List.from([
+  [0x6a09e667, 0xf3bcc908],
+  [0xbb67ae85, 0x84caa73b],
+  [0x3c6ef372, 0xfe94f82b],
+  [0xa54ff53a, 0x5f1d36f1],
+  [0x510e527f, 0xade682d1],
+  [0x9b05688c, 0x2b3e6c1f],
+  [0x1f83d9ab, 0xfb41bd6b],
+  [0x5be0cd19, 0x137e2179],
+]);
+
+final _blake2b_sigma = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+  [11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4],
+  [7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8],
+  [9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13],
+  [2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9],
+  [12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11],
+  [13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10],
+  [6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5],
+  [10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0],
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  [14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3],
+];

--- a/lib/impl.dart
+++ b/lib/impl.dart
@@ -29,6 +29,7 @@ import "package:pointycastle/block/modes/ofb.dart";
 import "package:pointycastle/block/modes/sic.dart";
 
 // digests
+import "package:pointycastle/digests/blake2b.dart";
 import "package:pointycastle/digests/md2.dart";
 import "package:pointycastle/digests/md4.dart";
 import "package:pointycastle/digests/md5.dart";

--- a/lib/src/ufixnum.dart
+++ b/lib/src/ufixnum.dart
@@ -254,6 +254,13 @@ class Register64 {
     }
   }
 
+  void sumReg(Register64 y) {
+    int slo32 = (_lo32 + y._lo32);
+    _lo32 = (slo32 & _MASK_32);
+    int carry = ((slo32 != _lo32) ? 1 : 0);
+    _hi32 = ((_hi32 + y._hi32 + carry) & _MASK_32);
+  }
+
   void sub(dynamic y) {
     // TODO: optimize sub() ???
     sum(new Register64(y)..neg());
@@ -400,7 +407,7 @@ class Register64 {
   }
 
   /**
-   * Unpacks a 32 bit integer from a byte buffer. The [inp] parameter can be an [Uint8List] or a
+   * Unpacks a 64 bit integer from a byte buffer. The [inp] parameter can be an [Uint8List] or a
    * [ByteData] if you will run it several times against the same buffer and want faster execution.
    */
   void unpack(dynamic inp, int offset, Endianness endian) {
@@ -458,9 +465,10 @@ class Register64List {
     }
   }
 
-  void setRange(int start, int end, Register64List list) {
-    for (var i = start; i < end; i++) {
-      _list[i].set(list[i]);
+  void setRange(int start, int end, Register64List list, [int skipCount = 0]) {
+    var length = end - start;
+    for (var i = 0; i < length; i++) {
+      _list[start + i].set(list[skipCount + i]);
     }
   }
 

--- a/test/all_tests_web.dart
+++ b/test/all_tests_web.dart
@@ -4,6 +4,7 @@ import "adapters/stream_cipher_as_block_cipher_test.dart" as stream_cipher_as_bl
 import "asymmetric/pkcs1_test.dart" as pkcs1_test;
 import "asymmetric/rsa_test.dart" as rsa_test;
 import "block/aes_fast_test.dart" as aes_fast_test;
+import "digests/blake2b_test.dart" as blake2b_test;
 import "digests/md2_test.dart" as md2_test;
 import "digests/md4_test.dart" as md4_test;
 import "digests/md5_test.dart" as md5_test;
@@ -47,6 +48,7 @@ void main() {
   pkcs1_test.main();
   rsa_test.main();
   aes_fast_test.main();
+  blake2b_test.main();
   md2_test.main();
   md4_test.main();
   md5_test.main();

--- a/test/digests/blake2b_test.dart
+++ b/test/digests/blake2b_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2013-present, the authors of the Pointy Castle project
+// This library is dually licensed under LGPL 3 and MPL 2.0.
+// See file LICENSE for more information.
+
+library pointycastle.test.digests.blake2b_test;
+
+import "package:pointycastle/pointycastle.dart";
+
+import "../test/digest_tests.dart";
+
+void main() {
+
+
+
+  runDigestTests( new Digest("Blake2b"), [
+
+    "",
+    "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce",
+
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit...",
+    "b26dc06e2a96f3a2d16313b8633e79c438317ba399ed143aa0a695c2c14df01bf7870ad2ee09b3ef7f0d36bba5c98541cbce3c6e802790b402534f757d2085d3",
+
+    "En un lugar de La Mancha, de cuyo nombre no quiero acordarme...",
+    "c782dabd3cabf2e74f2b6e9854fc6f274583cb77003e20625ec19efad78993480c237594841cef9933ac7a675a526426460d87bc0ef4538ed08d0e2744a22900",
+
+    "Lorem ipsum dolor sit amet, ex has ignota maluisset persecuti. Cum ad integre splendide adipiscing. An sit ipsum possim, dicunt ",
+    "ee370c9780381c360feeedc04fff3caa17687cde31e8a541d0a0053c3b92c0195d0f64e27126cba2e79f1b007f3ec9ab66f5fd9bca416654a05cfd94cb8da2be",
+
+    "Lorem ipsum dolor sit amet, ex has ignota maluisset persecuti. Cum ad integre splendide adipiscing. An sit ipsum possim, dicunt eirmod habemus mea at, in sea alii dolorem deterruisset. An habeo fabellas facilisis eum, aperiri imperdiet definitiones eum no. Aeque delicata eos et. Fierent platonem cum id.",
+    "79ca22680c4a9b72299eb22d173222b309d9f2b90f9f16bc170a143482d62b23029b6712758bf6135659adeeeaf8ad472b746674b5e10b7a4cb6b803b88c19db",
+
+  ]);
+
+}
+

--- a/test/impl_test.dart
+++ b/test/impl_test.dart
@@ -22,6 +22,7 @@ void main() {
     });
 
     test("Digest returns valid implementations", () {
+      testDigest("Blake2b");
       testDigest("MD2");
       testDigest("MD4");
       testDigest("MD5");

--- a/test/test/digest_tests.dart
+++ b/test/test/digest_tests.dart
@@ -4,6 +4,8 @@
 
 library pointycastle.test.test.digest_tests;
 
+import 'dart:typed_data';
+
 import "package:test/test.dart";
 import "package:pointycastle/pointycastle.dart";
 
@@ -39,5 +41,15 @@ void _runDigestTest( Digest digest, String plainTextString, String expectedHexDi
   var hexOut = formatBytesAsHexString(out);
 
   expect( hexOut, equals(expectedHexDigestText) );
+
+
+  for(var i = 0; i < plainText.length; ++i) {
+    digest.updateByte(plainText[i]);
+  }
+  out = new Uint8List(digest.digestSize);;
+  digest.doFinal(out, 0);
+  hexOut = formatBytesAsHexString(out);
+
+  expect(hexOut, equals(expectedHexDigestText));
 }
 


### PR DESCRIPTION
The implementation was ported from Bouncy Castle. It passes the included tests on both the VM and in Firefox. I got the hash values from b2sum, the reference implementation. I changed the digest test method to test both `update()` and `updateByte()` instead of just `update()`. The tests don't include passing a key, salt, or personalization. Let me know if you want me to add that in this PR.

I changed `Register64.setRange()` to behave like `List.setRange()` in the standard library. Before, it always copied corresponding indexes, even if you passed a start != 0. No existing uses depended on this (surprising to me) behavior.

I did some brief optimization. Making the `m` list a member variable instead of a local made the benchmark about 6% faster (because it reduces allocations?). Adding a `Register64.sumReg()` method that doesn't have a branch for `int` made it an additional ~6% faster. I'm not sure it can be optimized further, as most of the time is spent in `Register64` methods. Now on my i7-6700K 4.0GHz processor, I get about 40.5 MB/s.
