### PR TITLE
Add Padding: ISO7816-4 / iso7816d4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ As of the last release, the following algorithms are implemented:
 
 **Paddings:**
   * PKCS7
+  * ISO7816-4
 
 **Digests:**
   * Blake2b

--- a/lib/export.dart
+++ b/lib/export.dart
@@ -71,6 +71,7 @@ export "package:pointycastle/macs/hmac.dart";
 // paddings
 export "package:pointycastle/padded_block_cipher/padded_block_cipher_impl.dart";
 export "package:pointycastle/paddings/pkcs7.dart";
+export "package:pointycastle/paddings/iso7816d4.dart";
 
 // random
 export "package:pointycastle/random/auto_seed_block_ctr_random.dart";

--- a/lib/paddings/iso7816d4.dart
+++ b/lib/paddings/iso7816d4.dart
@@ -1,0 +1,58 @@
+// Copyright (c) 2013-present, the authors of the Pointy Castle project
+// This library is dually licensed under LGPL 3 and MPL 2.0.
+// See file LICENSE for more information.
+
+library pointycastle.impl.padding.iso7816d4;
+
+import "dart:typed_data" show Uint8List;
+
+import "package:pointycastle/api.dart";
+import "package:pointycastle/src/impl/base_padding.dart";
+import "package:pointycastle/src/registry/registry.dart";
+
+/// A padder that adds the padding according to the scheme referenced in
+/// ISO 7814-4 - scheme 2 from ISO 9797-1. The first byte is 0x80, rest is 0x00
+class ISO7816d4Padding extends BasePadding {
+  static final FactoryConfig FACTORY_CONFIG =
+      new StaticFactoryConfig(Padding, "ISO7816-4", () => ISO7816d4Padding());
+
+  String get algorithmName => "ISO7816-4";
+
+  @override
+  void init([CipherParameters params]) {
+    // nothing to do.
+  }
+
+  /// add the pad bytes to the passed in block, returning the
+  /// number of bytes added.
+  @override
+  int addPadding(Uint8List data, int offset) {
+    int added = (data.length - offset);
+
+    data[offset] = 0x80;
+    offset++;
+
+    while (offset < data.length) {
+      data[offset] = 0;
+      offset++;
+    }
+
+    return added;
+  }
+
+  /// return the number of pad bytes present in the block.
+  @override
+  int padCount(Uint8List data) {
+    int count = data.length - 1;
+
+    while (count > 0 && data[count] == 0) {
+      count--;
+    }
+
+    if (data[count] != 0x80) {
+      throw new ArgumentError("pad block corrupted");
+    }
+
+    return data.length - count;
+  }
+}

--- a/lib/src/registry/registration.dart
+++ b/lib/src/registry/registration.dart
@@ -76,6 +76,7 @@ import 'package:pointycastle/key_generators/rsa_key_generator.dart';
 import 'package:pointycastle/macs/hmac.dart';
 import 'package:pointycastle/padded_block_cipher/padded_block_cipher_impl.dart';
 import 'package:pointycastle/paddings/pkcs7.dart';
+import 'package:pointycastle/paddings/iso7816d4.dart';
 import 'package:pointycastle/random/auto_seed_block_ctr_random.dart';
 import 'package:pointycastle/random/block_ctr_random.dart';
 import 'package:pointycastle/random/fortuna_random.dart';
@@ -204,6 +205,7 @@ void _registerPaddedBlockCiphers(FactoryRegistry registry) {
 
 void _registerPaddings(FactoryRegistry registry) {
   registry.register(PKCS7Padding.FACTORY_CONFIG);
+  registry.register(ISO7816d4Padding.FACTORY_CONFIG);
 }
 
 void _registerRandoms(FactoryRegistry registry) {

--- a/test/all_tests_web.dart
+++ b/test/all_tests_web.dart
@@ -34,6 +34,7 @@ import "modes/ofb_test.dart" as ofb_test;
 import "modes/sic_test.dart" as sic_test;
 import "paddings/padded_block_cipher_test.dart" as padded_block_cipher_test;
 import "paddings/pkcs7_test.dart" as pkcs7_test;
+import "paddings/iso7816d4_test.dart" as iso7816d4_test;
 import "random/auto_seed_block_ctr_random_test.dart"
     as auto_seed_block_ctr_random_test;
 import "random/block_ctr_random_test.dart" as block_ctr_random_test;
@@ -80,6 +81,7 @@ void main() {
   sic_test.main();
   padded_block_cipher_test.main();
   pkcs7_test.main();
+  iso7816d4_test.main();
   auto_seed_block_ctr_random_test.main();
   block_ctr_random_test.main();
   fortuna_random_test.main();

--- a/test/impl_test.dart
+++ b/test/impl_test.dart
@@ -77,6 +77,7 @@ void main() {
 
     test("Padding returns valid implementations", () {
       testPadding("PKCS7");
+      testPadding("ISO7816-4");
     });
 
     test("SecureRandom returns valid implementations", () {

--- a/test/paddings/iso7816d4_test.dart
+++ b/test/paddings/iso7816d4_test.dart
@@ -1,0 +1,17 @@
+// Copyright (c) 2013-present, the authors of the Pointy Castle project
+// This library is dually licensed under LGPL 3 and MPL 2.0.
+// See file LICENSE for more information.
+
+library pointycastle.test.paddings.iso7816d4_test;
+
+import "package:pointycastle/pointycastle.dart";
+
+import "../test/padding_tests.dart";
+import "../test/src/helpers.dart";
+
+void main() {
+  runPaddingTest(new Padding("ISO7816-4"), null,
+      createUint8ListFromHexString("ffffff"), 8, "ffffff8000000000");
+  runPaddingTest(new Padding("ISO7816-4"), null,
+      createUint8ListFromHexString("00000000"), 8, "0000000080000000");
+}

--- a/test/paddings/pkcs7_test.dart
+++ b/test/paddings/pkcs7_test.dart
@@ -4,13 +4,20 @@
 
 library pointycastle.test.paddings.pkcs7_test;
 
+import "dart:typed_data" show Uint8List;
+
 import "package:pointycastle/pointycastle.dart";
 
 import "../test/padding_tests.dart";
+import "../test/src/helpers.dart";
 
 void main() {
-  runPaddingTest(new Padding("PKCS7"), null, "123456789", 16,
-      "31323334353637383907070707070707");
   runPaddingTest(
-      new Padding("PKCS7"), null, "", 16, "10101010101010101010101010101010");
+      new Padding("PKCS7"),
+      null,
+      createUint8ListFromString("123456789"),
+      16,
+      "31323334353637383907070707070707");
+  runPaddingTest(new Padding("PKCS7"), null, Uint8List.fromList([]), 16,
+      "10101010101010101010101010101010");
 }

--- a/test/test/padding_tests.dart
+++ b/test/test/padding_tests.dart
@@ -4,19 +4,19 @@
 
 library pointycastle.test.test.padding_tests;
 
-import "dart:typed_data";
+import "dart:typed_data" show Uint8List;
 
 import "package:test/test.dart";
 import "package:pointycastle/pointycastle.dart";
 
 import "./src/helpers.dart";
 
-void runPaddingTest(Padding pad, CipherParameters params, String unpadData,
+void runPaddingTest(Padding pad, CipherParameters params, Uint8List unpadData,
     int padLength, String padData) {
   group("${pad.algorithmName}:", () {
-    test("addPadding: $unpadData", () {
+    test("addPadding: ${unpadData.toString()}", () {
       var expectedBytes = createUint8ListFromHexString(padData);
-      var dataBytes = new Uint8List(padLength)..setAll(0, unpadData.codeUnits);
+      var dataBytes = new Uint8List(padLength)..setAll(0, unpadData);
 
       pad.init(params);
       var ret = pad.addPadding(dataBytes, unpadData.length);


### PR DESCRIPTION
Based on sources and test cases from BouncyCastle.

Refactored runPaddingTest to use Uint8List `unpadData` (input), in order to use the provided binary test cases from BouncyCastle.