### PR TITLE
RSA bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+#### Version TBD
+
+* Fixed OAEPEncoding and PKCS1Encoding to use provided output offset value.
+* Fixed RSA block length and offset checks in RSAEngine.processBlock.
+* Fixed RSASigner.verifySignature to return false when signature is bad.
 
 #### Version 1.0.2 (2019-11-15)
 

--- a/lib/asymmetric/oaep.dart
+++ b/lib/asymmetric/oaep.dart
@@ -228,9 +228,9 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
     Uint8List output = Uint8List(block.length - start);
     output = _arraycopy(block, start, output, 0, output.length);
 
-    var result = new Uint8List(block.length - start);
     var rlen = (block.length - start);
-    out.setRange(0, rlen, block.sublist(start));
+    var result = new Uint8List(rlen);
+    out.setRange(outOff, outOff + rlen, block.sublist(start));
     return rlen;
   }
 

--- a/lib/asymmetric/pkcs1.dart
+++ b/lib/asymmetric/pkcs1.dart
@@ -168,10 +168,9 @@ class PKCS1Encoding extends BaseAsymmetricBlockCipher {
       throw new ArgumentError("No data found in block, only padding");
     }
 
-    var result = new Uint8List(block.length - start);
-
     var rlen = (block.length - start);
-    out.setRange(0, rlen, block.sublist(start));
+    var result = new Uint8List(rlen);
+    out.setRange(outOff, outOff + rlen, block.sublist(start));
     return rlen;
   }
 }

--- a/lib/asymmetric/rsa.dart
+++ b/lib/asymmetric/rsa.dart
@@ -79,17 +79,19 @@ class RSAEngine extends BaseAsymmetricBlockCipher {
   BigInt _convertInput(Uint8List inp, int inpOff, int len) {
     var inpLen = inp.length;
 
-    if (inpLen > (inputBlockSize + 1)) {
-      throw new ArgumentError("Input too large for RSA cipher");
+    if (inpLen < inpOff + len) {
+      throw new ArgumentError.value(inpOff, "inpOff",
+          "Not enough data for RSA cipher (length=$len, available=$inpLen)");
     }
 
-    if ((inpLen == (inputBlockSize + 1)) && !_forEncryption) {
-      throw new ArgumentError("Input too large for RSA cipher");
+    if (inputBlockSize < len) {
+      throw new ArgumentError.value(len, "len",
+          "Too large for maximum RSA cipher input block size ($inputBlockSize)");
     }
 
     var res = utils.decodeBigInt(inp.sublist(inpOff, inpOff + len));
     if (res >= _key.modulus) {
-      throw new ArgumentError("Input too large for RSA cipher");
+      throw new ArgumentError("Input block too large for RSA key size");
     }
 
     return res;


### PR DESCRIPTION
Fixed three major bugs that prevented RSA code from working correctly.

### 1. Output block offsets were not being honoured in asymmetric block ciphers

In the `processBlock` methods of the two asymmetric block cipher implementations, the output offset parameter (`outOff`) was not being used at all.

Towards the end of the method, it used to say:

    out.setRange(0, rlen, block.sublist(start));

Which means it always wrote the block to the beginning of `out` instead of starting at the requested `outOff` offset into it. This bug appears when multiple blocks are being processed, since all the output blocks are written over each other at the beginning of the output buffer, instead of at the correct positions in the output buffer.

It has been changed to:

    out.setRange(outOff, outOff + rlen, block.sublist(start));

This is in _lib/asymmetric/oaep.dart_ and _lib/asymmetric/pkcs1.dart_.

### 2. RSAEngine checks were rejecting correct blocks

Several checks in the `RSAEngine.processBlock` method were wrong.

#### 2.1 Did not work if the plaintext spans over multiple blocks

This check is wrong, because the `inpLen` can be huge (when the plaintext is large). The method is only being asked to process `len` bytes from it starting at the `inpOff` offset -- it is not being asked to process the entire `inpLen` from it. It is the size of `len` that matters, not `inpLen`.

    if (inpLen > (inputBlockSize + 1))  { throw ... }

The check has been changed to check if there are `len` bytes remaining/available in the input, from `inpOff` to the end of the array.

    if (inpLen < inpOff + len) { throw ... }

#### 2.2 RSAEngine does not work the same as OAEPEncoding or PKCS1Encoding

This check is wrong, since when using the RSAEngine directly (i.e. without an asymmetric block cipher around it) to encrypt, the last block (or the first and only block) is usually shorter than the maximum input block size.

    if ((inpLen == (inputBlockSize + 1)) && !_forEncryption) { throw ... }

It is much simpler to just check if the block length is not larger than the allowed input block size. That test applies equally when encrypting or decrypting.

    if (inputBlockSize < len) { throw ... }

Of course, it is not secure to use the RSAEngine without an asymmetric block cipher (e.g. OAEP or PKCS #1), but from an API point of view, the RSAEngine is an implementation of AsymmetricBlockCipher, so it should function the same. If the aim is to prevent naive users from using the library insecurely, the exception should provide a meaningful error message (e.g. "For security reasons RSAEngine must be used with an asymmetric block cipher") instead of what it used to say ("Input too large for RSA cipher" - which was misleading anyway).

### 3. Signature verification throws exceptions instead of returning false

The `RSASigner.verifySignature` method used to throw an exception if the signature has been tapered with. It correctly returns false if the data was tampered with, but not when the signature was tampered with.

The exception comes from the `PKCS1Encoding._decodeBlock` which fails to detect the 0x01 type byte at the beginning of the block -- the block that was "decrypted" from the signature bytes. Obviously, if the signature bytes were tampered with in any way, the "decrypted" block will bear no resemblance to the original "plaintext" block. There will be a 1 in 256 chance it would find the type byte, and an even lower chance of it finding correct padding -- so the byte-by-byte comparison done in lines 125-131 of _lib/signers/rsa_signer.dart_ (that do return false) rarely gets used.

If the signature has been tampered with, the verifySignature method will usually throw an exception (with a confusing message) rather than return false.

The `verifySignature` method now catches the exception and returns false.
