### PR TITLE
Updated tutorials to use export.dart instead of multiple imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ classes can all be instantiated with a single name
 (e.g. "HMAC/SHA-256" or "SHA-1/HMAC/PBKDF2"), and they are
 automatically combined together with the correct values.
 
-For example,
+To use the registry, either import `pointycastle.dart` or
+`export.dart`.  For example,
 
 ```dart
+import "package:pointycastle/pointycastle.dart";
+
 final sha256 = Digest("SHA-256");
 final sha1 = Digest("SHA-1");
 final md5 = Digest("MD5");
@@ -131,9 +134,11 @@ If an algorithm involves multiple algorithm implementation classes,
 they each have to be individually instantiated and combined together
 with the correct values.
 
-For example,
+To use the constructors, import `export.dart`.  For example,
 
 ``` dart
+import "package:pointycastle/export.dart";
+
 final sha256 = SHA256Digest();
 final sha1 = SHA1Digest();
 final md5 = MD5Digest();
@@ -152,102 +157,31 @@ final signer = RSASigner(SHA256Digest(), '0609608648016503040201');
 Using the registry means that all algorithms will be imported by
 default, which can increase the compiled size of your program.
 
-To avoid this, instantiate all classes directly by using the
-constructors. But which classes can be instantiated with its
-constructor will depend on which libraries have been imported.
+To avoid this, instantiate **all** classes directly by using their
+constructors.
 
 ### Importing libraries
 
-A program can take one of these three approaches for importing Point
-Castle libraries:
+There are two main approaches for importing Point Castle libraries:
 
-- only import pointycastle.dart;
-- only import exports.dart; or
-- import api.dart and individual libraries as needed.
+- only import _pointycastle.dart_ (which includes the high-level API and
+  the interfaces); or
+- only import _export.dart_ (which includes the high-level API, interfaces
+  and all the implementation classes).
+  
+It is also possible to import _api.dart_ (the high-level API) and
+selectively import individual implementation classes as they are
+needed. But this method requires a lot more programmer effort, and no
+longer has any advantage over simply importing _export.dart_ and
+relying Dart's tree shaking to leave out code that is not needed.
 
-#### Only import pointycastle.dart
+The registry can be used with any of these approaches. The different
+approaches only affects access to the implementation classes.
 
-The "pointycastle.dart" file exports:
-
-- the high-level API; and
-- implementations of the interfaces.
-
-But it does not export any of the algorithm implementation classes.
-
-``` dart
-import "package:pointycastle/pointycastle.dart";
-```
-
-With this import, **none** of the implementation classes can be
-instantiated directly.  The program can only use the registry.
-
-For example,
-
-``` dart
-final sha256 = Digest("SHA-256");
-// final md5 = MD5Digest(); // not available
-final p = Padding("PKCS7");
-// final s = FortunaRandom(); // not available
-```
-
-#### Only import exports.dart
-
-The "export.dart" file exports:
-
-- the high-level API,
-- implementations of the interfaces; and
-- every algorithm implementation class.
-
-That is, everything!
-
-``` dart
-import "package:pointycastle/export.dart";
-```
-
-With this import, **all** of the implementation classes can be
-instantiated directly.  The program can also use the registry.
-
-
-For example, this works without any additional imports:
-
-``` dart
-final sha256 = Digest("SHA-256");
-final md5 = MD5Digest();
-final p = Padding("PKCS7");
-final s = FortunaRandom();
-```
-
-#### Import api.dart and individual libraries
-
-The "api.dart" exports only:
-
-- the high-level API.
-
-It does not include the implementations of the interfaces, nor any
-algorithm implementation class.
-
-``` dart
-import "package:pointycastle/api.dart";
-// additional imports will be needed
-```
-
-With this import, only **some** of the implementation classes can be
-instantiated directly (i.e. those that are also explicitly imported).
-The program can also use the registry.
-
-For example, the following only works because of the additional imports:
-
-``` dart
-// In addition to "package:pointycastle/api.dart":
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/digests/md5.dart"
-import 'package:pointycastle/paddings/pkcs7.dart';
-
-final sha256 = Digest("SHA-256");
-final md5 = MD5Digest();
-final p = Padding("PKCS7");
-// final s = FortunaRandom(); // not available without 'package:pointycastle/random/fortuna_random.dart'
-```
+Therefore, when avoiding the code size overheads of the registry, be
+careful not to accidentally use the registry. Since the single use of
+a factory from the registry will cause the entire registry to be
+loaded.
 
 ## Tutorials
 

--- a/tutorials/aes-cbc.md
+++ b/tutorials/aes-cbc.md
@@ -19,7 +19,7 @@ Initialization Vector (IV).
 
 There are three algorithms in the AES family: AES-128, AES-192 and
 AES-256, corresponding to the length of the keys in bits. For all the
-algorithms, the block size is always 128-bits (32 byte).
+algorithms, the block size is always 128-bits (32 bytes).
 
 To encrypt using AES-CBC:
 

--- a/tutorials/aes-cbc.md
+++ b/tutorials/aes-cbc.md
@@ -40,9 +40,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/block/aes_fast.dart";
-import 'package:pointycastle/block/modes/cbc.dart';
+import "package:pointycastle/export.dart";
 
 Uint8List aesCbcEncrypt(Uint8List key, Uint8List iv, Uint8List paddedPlaintext) {
   // Create a CBC block cipher with AES, and initialize with key and IV
@@ -110,15 +108,10 @@ final aesCbc = BlockCipher('AES/CBC');
 
 #### Without the registry
 
-If the registry is not used, explicitly import the libraries and
-instantiate the objects directly. Instantiate the AES object and then
-pass it in as the underlying cipher to the block cipher constructor.
+If the registry is not used, invoke the block cipher's constructor,
+passing in the AES implementation as a parameter.
 
 ```dart
-import "package:pointycastle/api.dart";
-import "package:pointycastle/block/aes_fast.dart";
-import 'package:pointycastle/block/modes/cbc.dart';
-
 final aesCbc = CBCBlockCipher(AESFastEngine());
 ```
 

--- a/tutorials/digest.md
+++ b/tutorials/digest.md
@@ -24,12 +24,11 @@ To calculate a digest value:
 
 This program calculates the SHA-265 digest of text strings:
 
-```
-import 'dart:convert;
+```dart
+import 'dart:convert';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/sha256.dart";
+import "package:pointycastle/export.dart";
 
 Uint8List sha256Digest(Uint8List dataToDigest) {
 
@@ -47,6 +46,9 @@ void main(List<String> args) {
 }
 ```
 
+Note: these overview examples do not use the registry. For information
+on how to use the registry, see the following details.
+
 ## Details
 
 ### Implementation
@@ -56,9 +58,7 @@ void main(List<String> args) {
 If using the registry, invoke the `Digest` factory with the name of
 the digest algorithm.
 
-```
-import 'package:pointycastle/pointycastle.dart';
-
+```dart
 final d = new Digest("SHA-256");
 ```
 
@@ -70,29 +70,24 @@ Note: these examples store the digest object in "d", since they could
 be for any digest algorithm. But it is better to give the variable a
 more meaningful name, such as "sha256".
 
+Some digest implementations should not be instantiated using the
+registry, because additional parameters need to be passed to their
+constructors. These include: `Blake2bDigest`, `SHA3Digest` and
+`SHA512tDigest`.
+
 #### Without the registry
 
-If the registery is not used, explicitly import the library that
-contains the implementation class and instantiate the object directly.
+If the registery is not used, invoke the digest implementation's
+constructor.
 
-```
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/sha256.dart";
-
+```dart
 final d = new SHA256Digest(); // SHA-256
 ```
 
 All of the available digest classes of are listed as the implementers
 of the
 [Digest](https://pub.dev/documentation/pointycastle/latest/pointycastle.api/Digest-class.html)
-class. Each digest implementation is in a libary under
-"pointycastle.impl.digest..."  and is imported from under
-"package:pointycastle/digests/...".
-
-Some digest implementations need to be instantiated directly (instead
-of using the registry), because parameters need to be passed to their
-constructors. These include: `Blake2bDigest`, `SHA3Digest` and
-`SHA512tDigest`.
+abstract class.
 
 ### Providing the data to digest
 

--- a/tutorials/digest.md
+++ b/tutorials/digest.md
@@ -98,7 +98,7 @@ the `process` method to obtain the digest. The input data must be a
 single `Uint8List`, and the calculated digest is returned in a new
 `Uint8List`.
 
-```
+```dart
 final Uint8List dataToDigest = ...
 
 final hash = d.process(dataToDigest);
@@ -124,7 +124,7 @@ The destination, after the offset position, must be large enough to
 hold the digest.  The number of bytes required depends on the digest
 algorithm being used, and can be found using the `digestSize` getter.
 
-```
+```dart
 final chunk1 = utf8.encode('cellophane');
 final chunk2 = utf8.encode('world');
 
@@ -149,7 +149,7 @@ Normally, reset does not need to be explicitly done because it is done
 automatically by the `process` and `doFinal` methods.  This is only
 required if previously provided data is abandoned.
 
-```
+```dart
 final part1 = utf8.encode('Hello ');
 final part2 = utf8.encode('world!');
 

--- a/tutorials/examples/aes-cbc-direct.dart
+++ b/tutorials/examples/aes-cbc-direct.dart
@@ -6,15 +6,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/block/aes_fast.dart";
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/key_derivators/api.dart";
-import "package:pointycastle/key_derivators/pbkdf2.dart";
-import "package:pointycastle/macs/hmac.dart";
-import 'package:pointycastle/block/modes/cbc.dart';
-import 'package:pointycastle/paddings/pkcs7.dart';
-import 'package:pointycastle/random/fortuna_random.dart';
+import "package:pointycastle/export.dart";
 
 // Code convention: variable names starting with underscores are examples only,
 // and should be implementated according to the needs of the program.

--- a/tutorials/examples/digest-direct.dart
+++ b/tutorials/examples/digest-direct.dart
@@ -17,8 +17,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/sha256.dart";
+import "package:pointycastle/export.dart";
 
 Uint8List sha256Digest(Uint8List dataToDigest) {
   final d = SHA256Digest();

--- a/tutorials/examples/hmac-direct.dart
+++ b/tutorials/examples/hmac-direct.dart
@@ -11,14 +11,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/macs/hmac.dart";
-
-import "package:pointycastle/digests/md2.dart";
-import "package:pointycastle/digests/md5.dart";
-import "package:pointycastle/digests/sha1.dart";
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/digests/sha512.dart";
+import "package:pointycastle/export.dart";
 
 Uint8List hmacSha1(Uint8List hmacKey, Uint8List data) {
   final hmac = HMac(SHA256Digest(), 64) // HMAC SHA-256 must use block length of 64

--- a/tutorials/examples/rsa-demo.dart
+++ b/tutorials/examples/rsa-demo.dart
@@ -12,21 +12,10 @@ import 'dart:math';
 import 'dart:typed_data';
 
 // For using the registry:
-
 //import 'package:pointycastle/pointycastle.dart';
 
 // When not using the registry:
-
-import "package:pointycastle/api.dart";
-import 'package:pointycastle/asymmetric/api.dart';
-import 'package:pointycastle/asymmetric/oaep.dart';
-import 'package:pointycastle/asymmetric/rsa.dart';
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/key_generators/api.dart";
-import "package:pointycastle/key_generators/rsa_key_generator.dart";
-import "package:pointycastle/signers/rsa_signer.dart";
-import 'package:pointycastle/random/fortuna_random.dart';
-import 'package:pointycastle/asymmetric/pkcs1.dart';
+import "package:pointycastle/export.dart";
 
 //================================================================
 // Test data

--- a/tutorials/hmac.md
+++ b/tutorials/hmac.md
@@ -22,9 +22,7 @@ This program calculates the HMAC SHA-256:
 import 'dart:convert';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/macs/hmac.dart";
+import "package:pointycastle/export.dart";
 
 Uint8List hmacSha256(Uint8List hmacKey, Uint8List data) {
   final hmac = HMac(SHA256Digest(), 64) // for HMAC SHA-256, block length must be 64
@@ -52,40 +50,18 @@ If using the registry, invoke the `Mac` factory with the name of the
 HMAC algorithm. The name of the HMAC algorithm is the name of the
 digest algorithm followed by "/HMAC" (e.g. "SHA-1/HMAC").
 
-```
-import 'package:pointycastle/pointycastle.dart';
-
+```dart
 final hmac = new Mac("SHA-256/HMAC");
 ```
 
 #### Without the registry
 
-If the registry is not used, explicitly import the libraries with the
-`HMac` class and the digest algorithm class.  and instantiate the
-objects directly.
+If the registry is not used, invoke the `HMac` constructor, passing it
+the digest implementation to use and a block length for that digest
+algorithm.
 
-```
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/macs/hmac.dart";
-
+```dart
 final hmacSha256 = HMac(SHA256Digest(), 64); // for HMAC SHA-256, block length must be 64
-```
-
-The `HMac` constructor has two parameters: the digest object and the
-block length. For example, the block length must be 64 for MD4, MD5,
-SHA-1, SHA-224, SHA-256, Tiger and Whirlpool; and must be 128 for
-SHA-384 and SHA 512.
-
-Example of other digest algorithms:
-
-```
-import "package:pointycastle/api.dart";
-import "package:pointycastle/digests/md2.dart";
-import "package:pointycastle/digests/md5.dart";
-import "package:pointycastle/digests/sha1.dart";
-import "package:pointycastle/digests/sha512.dart";
-import "package:pointycastle/macs/hmac.dart";
 
 final hmacSha1 = HMac(SHA1Digest(), 64); // for HMAC SHA-1, block length must be 64
 final hmacSha512 = HMac(SHA512Digest(), 128); // for HMAC SHA-512, block length must be 128
@@ -178,7 +154,7 @@ final part2 = utf8.encode('world!');
 
 final result = Uint8List(hmac.macSize);
 
-// Without rest
+// Without reset
 
 hmac.update(part1, 0, part1.length);
 hmac.update(part2, 0, part2.length);
@@ -187,7 +163,7 @@ hmac.doFinal(result, 0); // result contains HMAC of "Hello world!"
 // With reset
 
 hmac.update(part1, 0, part1.length);
-hmac.reset();
+hmac.reset(); // *** reset discards the data from part1
 hmac.update(part2, 0, part2.length);
 hmac.doFinal(result, 0); // result contains HMAC of "world!"
 ```

--- a/tutorials/hmac.md
+++ b/tutorials/hmac.md
@@ -18,7 +18,7 @@ To calculate a HMAC:
 
 This program calculates the HMAC SHA-256:
 
-```
+```dart
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -81,7 +81,7 @@ must be found and explicitly provided.
 Before processing the data, initialize the `HMac` object with the HMAC key
 as a key parameter.
 
-```
+```dart
 Uint8List keyBytes = ...
 
 hmac.init(KeyParameter(keyBytes));
@@ -97,7 +97,7 @@ If all the data is available as a single sequence of bytes, pass it to
 the `process` method to obtain the HMAC. The input data must be a
 `Uint8List`, and the calculated HMAC is returned in a new `Uint8List`.
 
-```
+```dart
 final Uint8List data = ...
 
 final hmacValue = hmac.process(data);
@@ -123,7 +123,7 @@ The destination, after the offset position, must be large enough to
 hold the HMAC.  The number of bytes required depends on the HMAC
 algorithm being used, and can be found using the `macSize` getter.
 
-```
+```dart
 final chunk1 = utf8.encode('cellophane');
 final chunk2 = utf8.encode('world');
 
@@ -148,7 +148,7 @@ Normally, reset does not need to be explicitly done because it is done
 automatically by the `process` and `doFinal` methods.  This is only
 required if previously provided data is abandoned.
 
-```
+```dart
 final part1 = utf8.encode('Hello ');
 final part2 = utf8.encode('world!');
 

--- a/tutorials/rsa.md
+++ b/tutorials/rsa.md
@@ -68,6 +68,8 @@ SecureRandom exampleSecureRandom() {
   return secureRandom;
 }
 
+...
+
 final pair = generateRSAkeyPair(exampleSecureRandom());
 final public = pair.publicKey;
 final private = pair.privateKey;
@@ -103,7 +105,7 @@ The RSA key generator must be initialized with both an
 This is done by creating a `ParametersWithRandom` with the two, and
 passing that to the key generator `init` method.
 
-```
+```dart
 SecureRandom mySecureRandom = ...
 
 final rsaParams = RSAKeyGeneratorParameters(BigInt.parse('65537'), 2048, 64);
@@ -126,7 +128,7 @@ The `RSAKeyGeneratorParameters` has:
 Invoke the `generateKeyPair` method on the `RSAKeyGenrator` to
 generate the key pair.
 
-```
+```dart
 final pair = keyGen.generateKeyPair();
 
 final myPublic = pair.publicKey as RSAPublicKey;
@@ -167,7 +169,7 @@ To verify a signature:
 The following functions creates a signature and verifies a signature
 using SHA-256 as the digest algorithm:
 
-```
+```dart
 import "package:pointycastle/export.dart";
 
 Uint8List rsaSign(RSAPrivateKey privateKey, Uint8List dataToSign) {
@@ -214,7 +216,7 @@ If using the registry, invoke the `Signer` factory with the name of
 the digest algorithm and signing algorithm (e.g. "SHA-256/RSA" or
 "SHA-1/RSA").
 
-```
+```dart
 final signer = Signer('SHA-256/RSA');
 ```
 
@@ -224,7 +226,7 @@ If the registry is not used, instantiate the `RSASigner` constructor,
 passing in a digest implemenetation object and the identifier for that
 digest algorithm.
 
-```
+```dart
 final signer = RSASigner(SHA256Digest(), '0609608648016503040201');
 ```
 
@@ -275,13 +277,13 @@ parameter is an RSA key.
 
 For signing, use true and the private key.
 
-```
+```dart
   signer.init(true, PrivateKeyParameter<RSAPrivateKey>(privateKey));
 ```
 
 For verifying, use false and the public key.
 
-```
+```dart
   verifier.init(false, PublicKeyParameter<RSAPublicKey>(publicKey));
 ```
 
@@ -293,7 +295,7 @@ the `generateSignature` method.
 It returns an `RSASignature`, from which the bytes making up the
 signature can be obtained using the `bytes` getter.
 
-```
+```dart
 Uint8List dataToSign = ...
 
 final sig = signer.generateSignature(dataToSign);

--- a/tutorials/rsa.md
+++ b/tutorials/rsa.md
@@ -31,10 +31,7 @@ This is a function to generate an RSA key pair:
 import 'dart:math';
 import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import 'package:pointycastle/asymmetric/api.dart';
-import "package:pointycastle/key_generators/api.dart";
-import 'package:pointycastle/random/fortuna_random.dart';
+import "package:pointycastle/export.dart";
 
 AsymmetricKeyPair<RSAPublicKey, RSAPrivateKey> generateRSAkeyPair(
     SecureRandom secureRandom,
@@ -76,8 +73,6 @@ final public = pair.publicKey;
 final private = pair.privateKey;
 ```
 
-### Secure random number generator
-
 The key generator requires an instance of `SecureRandom`. The above
 example shows the use of the Fortuna random number generator
 (initialized with a less-secure random seed), but other methods can be
@@ -95,13 +90,9 @@ final keyGen = KeyGenerator('RSA');
 
 #### Without the registry
 
-If the registry is not used, explicitly import the libraries and instantiate the `RSAKeyGenerator` directly.
+If the registry is not used, invoke the `RSAKeyGenerator` constructor.
 
 ```dart
-import "package:pointycastle/api.dart";
-import 'package:pointycastle/asymmetric/api.dart';
-import "package:pointycastle/key_generators/api.dart";
-
 final keyGen = RSAKeyGenerator();
 ```
 
@@ -177,10 +168,7 @@ The following functions creates a signature and verifies a signature
 using SHA-256 as the digest algorithm:
 
 ```
-import "package:pointycastle/api.dart";
-import 'package:pointycastle/asymmetric/api.dart';
-import "package:pointycastle/digests/sha256.dart";
-import "package:pointycastle/signers/rsa_signer.dart";
+import "package:pointycastle/export.dart";
 
 Uint8List rsaSign(RSAPrivateKey privateKey, Uint8List dataToSign) {
 
@@ -209,6 +197,15 @@ bool rsaVerify(
 }
 ```
 
+### Standards supported
+
+Pointy Castle implements PKCS #1 version 2.0 signature and
+verification. Specifically, it implements the _RSASSA-PKCS1-v1_5_
+signature scheme with appendix from section 8.1 of [RFC
+2437](https://tools.ietf.org/html/rfc2437#section-8.1): which defines
+how the digest algorithm identifier and digest value is encoded, and
+how that encoding is then signed using RSA.
+
 ### Implementation
 
 #### Using the registry
@@ -223,12 +220,12 @@ final signer = Signer('SHA-256/RSA');
 
 #### Without the registry
 
-If the registry is not used, explicitly import the libraries and
-instantiate the objects directly. Instantiate a Digest object and pass
-it as the first argument to the constructor for the `RSASigner`.
+If the registry is not used, instantiate the `RSASigner` constructor,
+passing in a digest implemenetation object and the identifier for that
+digest algorithm.
 
 ```
-  final signer = RSASigner(SHA256Digest(), '0609608648016503040201');
+final signer = RSASigner(SHA256Digest(), '0609608648016503040201');
 ```
 
 The second parameter identifies the signing algorithm being used, and
@@ -313,59 +310,27 @@ method.
 It returns true if the signature is valid, otherwise it should return
 false.
 
+```dart
+final sig = RSASignature(signatureBytes);
+
+final sigOk = verifier.verifySignature(signedData, sig);
+```
+
 Note: in Pointy Castle 1.0.2 and earlier, `verifySignature` returns
 false if the data had been modified, but will usually throw an
-`ArgumentError` if the signature had been modified.
+`ArgumentError` if the signature had been modified. The exception
+should be caught and treated as the signature failed to verify.
 
-```
+```dart
 final sig = RSASignature(signatureBytes);
 
 bool sigOk;
 try {
   sigOk = verifier.verifySignature(signedData, sig);
 } on ArgumentError {
-  sigOk = false;
+  sigOk = false; // required for Pointy Castle 1.0.2 and earlier
 }
 ```
-
-### Internal details
-
-It is useful to know what is contained in the signature bytes, 
-if the program needs to interoperate with another program
-that was not implemented with Pointy Castle.
-
-The signature is created from: the digest of the data, and the digest
-algorithm identifier OID.
-
-After calculating the digest over the data, a DER encoding is created
-of an ASN.1 Object whose tag is 48 (0x30) which contains a sequence
-of:
-
-- (tag 0x30) ASN.1 OBJECT IDENTIFIER with the algorithm identifier
-- (tag 0x05) ASN.1 NULL
-- (tag 0x04) ASN.1 OCTET STRING containing the digest bytes
-
-The value of the algorithm identifier is the Object Identifier that
-was provided to the `init` method (as a hexadecimal string), but
-ignoring its tag and always using 0x30 as the tag.
-
-A block is created, whose size depends on the bit-length of the RSA
-keys. The first byte of the block is a type code byte with the value
-of 0x01, followed by as many 0xFF padding bytes as needed, a single
-end-of-padding 0x00 byte, and finally the DER bytes.
-
-The block is then processed with the private key. That is, the bytes
-are interpreted as a large integer, the RSA formula is applied to that
-large integer and numbers from the private key, and the resulting
-number represented as bytes. Those final bytes are the bytes that make
-up the signature.
-
-When verifying a signature, a digest is calculated on the data that
-was supposedly signed. A calculated block is created in the same way
-(which is why verifier must be initialized with the same algorithm
-identifier OID). The signature being verified is processed with the
-public key, to produced a recovered block.  If the recovered block are
-the same as the calculated block, then the signature is valid.
 
 ## RSA encryption and decryption
 
@@ -383,26 +348,11 @@ To decrypt using RSA and an asymmetric block cipher:
 3. Invoke the object's `processBlock` method with the ciphertext blocks
    to produce the plaintext blocks.
 
-
-Pointy Castle has implementations of these asymmetric block ciphers:
-
-- Optimal Asymmetric Encryption Padding (OAEP), implemented by the `OAEPEncoding` class
-- PKCS #1, implemented by the `PKCS1Encoding` class.
-
-Note: RFC 2437 says, "OAEP is recommended for new applications;
-PKCS #1 is included only for compatibility with existing applications, and
-is not recommended for new applications."
-
-Pointy Castle implements the _Encoding Method for Encryption OAEP_
-(EME-OAEP) from PKCS #1 version 2.0. The EME-OAEP in PKCS #1 version
-2.1 was changed in a non-backward compatible way. Therefore, a program
-written using Point Castle's implementation of OAEP cannot
-interoperate with other programs that use OAEP from PKCS #1 version
-2.1 or later.
-
-The following functions encrypt and decrypt data using RSA with OAEP:
+For example,
 
 ```dart
+import "package:pointycastle/export.dart";
+
 Uint8List rsaEncrypt(RSAPublicKey myPublic, Uint8List dataToEncrypt) {
   final encryptor = OAEPEncoding(RSAEngine())
     ..init(true, PublicKeyParameter<RSAPublicKey>(myPublic)); // true=encrypt
@@ -442,32 +392,50 @@ Uint8List _processInBlocks(AsymmetricBlockCipher engine, Uint8List input) {
 }
 ```
 
+### Standards supported
+
+Pointy Castle implements PKCS #1 version 2.0 encryption and
+decryption. Specifically, it implements the RSAES-OAEP and
+RSAES-PKCS1-v1_5 encryption schemes from section 7 of [RFC
+2437](https://tools.ietf.org/html/rfc2437#section-7): which defines
+how the plaintext data is encoded, and how that encoding is then
+encrypted using RSA.
+
+- RSA Encryption Scheme Optimal Asymmetric Encryption Padding
+  (RSAES-OAEP) is implemented by the `OAEPEncoding` class.
+
+- RSA Encryption Scheme from PKCS #1 version 1.5 (RSAES-PKCS1-v1_5),
+  is implemented by the `PKCS1Encoding` class.
+
+**Important:** RSAES-OAEP was changed in PKCS #1 version 2.1, in a way
+that is not compatible with it in version 2.0. Therefore, Pointy
+Castle's implementation of OAEP cannot interoperate with programs that
+expect OAEP from PKCS #1 version 2.1 or later.
+
+RFC 2437 says, "RSAES-OAEP is recommended for new applications;
+RSAES-PKCS1-v1_5 is included only for compatibility with existing
+applications, and is not recommended for new applications."
+
 ### Implementation
 
 #### Using the registry
 
 If using the registry, invoke the `AsymmetricBlockCipher` factory with
-the name of the asymmetric block cipher: "RSA/OAEP", "RSA/PKCS1" or
-"RSA".
+the name of the asymmetric block cipher: "RSA/OAEP" or "RSA/PKCS1".
 
 ```dart
-final encryptor = AsymmetricBlockCipher('RSA/OAEP');
+final p = AsymmetricBlockCipher('RSA/OAEP');
+
+// final p = AsymmetricBlockCipher('RSA/PKCS1);
 ```
 
 #### Without the registry
 
-If the registry is not used, explicitly import the libraries and instantiate the object directly.
-
-When creating the `PKCS1Encoding` and `OAEPEncoding`, the `RSAEngine`
-needs to be provided to its constructor.
+If the registry is not used, invoke the constructor for
+`PKCS1Encoding` or `OAEPEncoding`, providing an instance of the
+`RSAEngine` as a parameter.
 
 ```dart
-import "package:pointycastle/api.dart";
-import 'package:pointycastle/asymmetric/api.dart';
-import 'package:pointycastle/asymmetric/oaep.dart';
-import 'package:pointycastle/asymmetric/pkcs1.dart';
-import 'package:pointycastle/asymmetric/rsa.dart';
-
 final p = OAEPEncoding(RSAEngine());
 
 // final p = PKCS1Encoding(RSAEngine());
@@ -497,9 +465,9 @@ The data being encrypted/decrypted must be processed in blocks. Each
 input block is processed into an output block.
 
 The maximum size of a block can be obtained from the `inputBlockSize`
-and `outputBlockSize` getters. They have different values, and
-therefore care must be taken to use the correct size when stepping
-through the input and output.
+and `outputBlockSize` getters. They usually have different values, so
+care must be taken to use the correct size when stepping through the
+input and output.
 
 The values are a _maximum_, so the input blocks can be smaller. But
 it usually only makes sense for the final block to be smaller, and all
@@ -514,8 +482,8 @@ The `processBlock` method has five arguments:
 - offset into the output where the block starts writing from
 
 It returns the number of bytes written. Which is especially important
-for the last block, which can be smaller than the maximum output block
-size.
+when the last block is smaller than the maximum size. Always use the
+returned output size to know how much of the output is valid.
 
 If the ciphertext cannot be decrypted, an `ArgumentError` is thrown.
 The message associated with the `ArgumentError` can be ignored, since
@@ -527,56 +495,4 @@ was thrown), it does not guarantee the result is the same as the
 plaintext that was encrypted. Encryption is designed to provides
 confidentiality, and not integrity.  If data integrity is important,
 additional mechanisms -- such as digests, HMACs or signatures --
-should also be used.
-
-### Internal details
-
-#### OAEP
-
-When encrypting in the OAEP asymmetric block cipher mode, the maximum
-input block size is 41 bytes smaller than the maximum input block size
-of the underlying RSA engine (Pointy Castle's implementation of OAEP
-is hard-coded to use SHA-1 as its hash function).
-
-For each input block, a block using the OAEP Encoding Method for
-Encryption (EME-OAEP) is created. The EME-OAEP block is always the
-maximum block size of the underlying RSA engine. The Mask Generation
-Function used to create the block is the default MGF1 function. The
-EME-OAEP block is encrypted by the underlying RSA engine (as described
-below).
-
-As mentioned before, Pointy Castle implements OAEP from PKCS #1
-version 2.0. This is not compatible with OAEP from PKCS #1 version 2.1
-or later.
-
-#### PKCS #1
-
-When encrypting in the PKCS #1 asymmetric block cipher mode, the
-maximum input block size is always 10 bytes smaller than the maximum
-input block size of the underlying RSA engine.
-
-From each input block, another block is produced that is always the
-maximum block size of the underlying RSA engine. This larger block
-contains:
-
-- a type code byte of 0x02;
-- random non-zero padding bytes (at least eight bytes);
-- end-of-padding zero byte (0x00); and
-- all the bytes from the input block.
-
-This expanded block is encrypted by the underlying RSA engine (as
-described in the next section).
-
-#### RSA
-
-The `RSAEngine` encrypts by interpreting every byte of the entire
-input block as a large integer.  The RSA formula is applied to that
-large integer and the numbers from the public key, and the resulting
-number represented as bytes. Those final bytes are the bytes that make
-up the output block.
-
-The `RSAEngine` must always be used with a padding scheme, such as
-OAEP or PKCS #1 described above. RSA is a deterministic algorithm
-which is vulnerable to various forms of attack if padding (and
-preferably randomness) is added.
-
+should used in conjunction with encryption.


### PR DESCRIPTION
Here is an updated README and tutorials.

For the non-registry case, they now just import "package:pointycastle/export.dart", instead of "package:pointycastle/api.dart" plus each individual implementation library. Since we now know there is no advantage in doing that extra work.

Also, since we now know about the specification of _PKCS#1 version 2.0_ in RFC 2437, the RSA tutorial can simply refer to it, and the low level "internal details" sections have been removed.