### PR TITLE
add normalize option for ecdsa signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 * Fixed OAEPEncoding and PKCS1Encoding to use provided output offset value.
 * Fixed RSA block length and offset checks in RSAEngine.processBlock.
 * Fixed RSASigner.verifySignature to return false when signature is bad.
+* Add optional `normalize` boolean on `generateSignature` and `normalize` function on `ECSignature` to convert an ecdsa signature to lower-s form
 
 #### Version 1.0.2 (2019-11-15)
 

--- a/lib/ecc/api.dart
+++ b/lib/ecc/api.dart
@@ -157,9 +157,24 @@ class ECPublicKey extends ECAsymmetricKey implements PublicKey {
 /// A [Signature] created with ECC.
 class ECSignature implements Signature {
   final BigInt r;
-  final BigInt s;
+  BigInt s;
 
   ECSignature(this.r, this.s);
+
+  /**
+   * 'normalize' this signature by converting its s to lower-s form if necessary
+   * This is required to validate this signature with some libraries such as libsecp256k1
+   * which enforce lower-s form for all signatures to combat ecdsa signature malleability
+   *
+   * Returns false if the signature was already normalized, or true if it changed
+   */
+  bool normalize(ECDomainParameters curveParams) {
+    if (s.compareTo(curveParams.n >> 1) > 0) {
+      s = curveParams.n - s;
+      return true;
+    }
+    return false;
+  }
 
   String toString() => "(${r.toString()},${s.toString()})";
 

--- a/lib/signers/ecdsa_signer.dart
+++ b/lib/signers/ecdsa_signer.dart
@@ -89,7 +89,7 @@ class ECDSASigner implements Signer {
     }
   }
 
-  Signature generateSignature(Uint8List message) {
+  Signature generateSignature(Uint8List message, {bool normalize = false}) {
     message = _hashMessageIfNeeded(message);
 
     var n = _pvkey.parameters.n;
@@ -126,7 +126,9 @@ class ECDSASigner implements Signer {
       s = (k.modInverse(n) * (e + (d * r))) % n;
     } while (s == BigInt.zero);
 
-    return new ECSignature(r, s);
+    var signature = new ECSignature(r, s);
+    if (normalize) signature.normalize(_pvkey.parameters);
+    return signature;
   }
 
   bool verifySignature(Uint8List message, covariant ECSignature signature) {

--- a/lib/signers/rsa_signer.dart
+++ b/lib/signers/rsa_signer.dart
@@ -80,7 +80,7 @@ class RSASigner implements Signer {
     _rsa.init(forSigning, params);
   }
 
-  RSASignature generateSignature(Uint8List message) {
+  RSASignature generateSignature(Uint8List message, {bool normalize = false}) {
     if (!_forSigning) {
       throw new StateError(
           "Signer was not initialised for signature generation");

--- a/lib/src/api/signer.dart
+++ b/lib/src/api/signer.dart
@@ -22,7 +22,7 @@ abstract class Signer extends Algorithm {
   void init(bool forSigning, CipherParameters params);
 
   /// Sign the passed in [message] (usually the output of a hash function)
-  Signature generateSignature(Uint8List message);
+  Signature generateSignature(Uint8List message, {bool normalize = false});
 
   /// Verify the [message] against the [signature].
   bool verifySignature(Uint8List message, Signature signature);

--- a/test/signers/ecdsa_signer_test.dart
+++ b/test/signers/ecdsa_signer_test.dart
@@ -43,6 +43,15 @@ void main() {
     _newSignature("4087581495017442027693712553398765118791696551913571321320",
         "4593990646726045634082084213208629584972116888758459298644"),
   ]);
+
+  runSignerTests(new Signer("SHA-1/DET-ECDSA"), signParams, verifyParams, [
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit ........",
+    _newSignature("6052012072724008730564193612572794050491696411960275629627",
+        "2161019278549597185578307509265728228343111084484752661213"),
+    "En un lugar de La Mancha, de cuyo nombre no quiero acordarme ...",
+    _newSignature("4087581495017442027693712553398765118791696551913571321320",
+        "1683111088660635129753705209967429428795077884424382985437"),
+  ], normalize: true);
 }
 
 ECSignature _newSignature(String r, String s) =>

--- a/test/test/signer_tests.dart
+++ b/test/test/signer_tests.dart
@@ -10,7 +10,7 @@ import "package:pointycastle/pointycastle.dart";
 import "./src/helpers.dart";
 
 void runSignerTests(Signer signer, CipherParameters signParams(),
-    CipherParameters verifyParams(), List messageSignaturePairs) {
+    CipherParameters verifyParams(), List messageSignaturePairs, {bool normalize = false}) {
   group("${signer.algorithmName}:", () {
     group("generateSignature:", () {
       for (var i = 0; i < messageSignaturePairs.length; i += 2) {
@@ -20,7 +20,7 @@ void runSignerTests(Signer signer, CipherParameters signParams(),
         test(
             "${formatAsTruncated(message)}",
             () => _runGenerateSignatureTest(
-                signer, signParams, message, signature));
+                signer, signParams, message, signature, normalize: normalize));
       }
     });
 
@@ -39,11 +39,11 @@ void runSignerTests(Signer signer, CipherParameters signParams(),
 }
 
 void _runGenerateSignatureTest(Signer signer, CipherParameters params(),
-    String message, Signature expectedSignature) {
+    String message, Signature expectedSignature, {bool normalize = false}) {
   signer.reset();
   signer.init(true, params());
 
-  var signature = signer.generateSignature(createUint8ListFromString(message));
+  var signature = signer.generateSignature(createUint8ListFromString(message), normalize: normalize);
 
   expect(signature, expectedSignature);
 }


### PR DESCRIPTION
Fixes #215 

Adds option to normalize ecdsa signatures to their lower-s form, required by some ecdsa libraries in an effort to prevent signature malleability

See this comment in libsecp256k1 for more information: https://github.com/bitcoin-core/secp256k1/blob/d644dda5c9dbdecee52d1aa259235510fdc2d4ee/include/secp256k1.h#L483-L513