### PR TITLE
OAEP bug fix for non-deterministically failing on decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 * Fixed OAEPEncoding and PKCS1Encoding to use provided output offset value.
 * Fixed RSA block length and offset checks in RSAEngine.processBlock.
 * Fixed RSASigner.verifySignature to return false when signature is bad.
+* Fixed randomly occuring bug with OAEP decoding.
 
 #### Version 1.0.2 (2019-11-15)
 

--- a/lib/asymmetric/oaep.dart
+++ b/lib/asymmetric/oaep.dart
@@ -322,12 +322,37 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
       throw ArgumentError.value(inpLen, 'inpLen', 'decryption error');
     }
 
-    // 2, 3, 4. RSA decryption
-    // This saves the _EM_ into [block].
+    // 2, 3. RSA decryption
 
-    var block = new Uint8List(_engine.inputBlockSize);
-    var len = _engine.processBlock(inp, inpOff, inpLen, block, 0);
-    block = block.sublist(0, len);
+    var block = new Uint8List(_engine.outputBlockSize);
+
+    var decryptFailed = false;
+    try {
+      var len = _engine.processBlock(inp, inpOff, inpLen, block, 0);
+
+      // 4. EM = I2OSP(m, k-1)
+
+      if (len < block.length) {
+        // Decrypted bytes is shorter than expected. Add 0x00 bytes at the
+        // beginning of the block (i.e. ensure it is k-1 long). This is needed
+        // when there were 0x00 in the leading bytes of the block that was
+        // originally encrypted.
+
+        // Note: do not use [_arrayCopy] or [SetRange], since the source and
+        // destination may overlap. Those methods will corrupt the data.
+
+        // Copy [len] data bytes from beginning of block to its end. I.e. from
+        // block[block.length - 1] <- block[len - 1] through to
+        // block[block.len - len] <- block[0]
+        for (var x = 0; x < len; x++) {
+          block[block.length - 1 - x] = block[len - 1 - x];
+        }
+        // Put 0x00 in those beginning bytes. Important: do this AFTER copying
+        block.fillRange(0, block.length - len, 0x00);
+      }
+    } on ArgumentError {
+      decryptFailed = true;
+    }
 
     // 5. EME-OAEP decoding
     //
@@ -408,10 +433,10 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
     // The data-start-is-wrong if the rest of the [block] contains all 0x00
     // bytes or that first non-zero byte is not 0x01.
 
-    bool dataStartWrong = (start > (block.length - 1)) | (block[start] != 1);
+    bool dataStartWrong = (start > (block.length - 1)) | (block[start] != 0x01);
     start++;
 
-    if (defHashWrong | wrongData | dataStartWrong) {
+    if (decryptFailed || defHashWrong || wrongData || dataStartWrong) {
       block.fillRange(0, block.length, 0);
       throw new ArgumentError("decoding error");
     }

--- a/lib/asymmetric/oaep.dart
+++ b/lib/asymmetric/oaep.dart
@@ -192,7 +192,7 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
     // bytes). (Not sure why it is a member variable instead of a variable
     // local to this method.)
 
-    // 5. Create the _DB_ data block.
+    // 5. Calculate _DB_ = pHash || PS || 01 || M
     //
     // It is the concatenation of _pHash_, _PS_, 0x01 and the message.
     // Note: RFC 2437 also includes "other padding", but that is an error that
@@ -203,23 +203,18 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
 
     var block = new Uint8List(inputBlockSize + 1 + 2 * defHash.length);
 
-    //
-    // copy in the message
+    // M: copy the message into the end of the block.
     //
     // block.setRange(inpOff, block.length - inpLen, inp.sublist(inpLen));
     block = _arraycopy(inp, inpOff, block, block.length - inpLen, inpLen);
 
-    //
-    // add sentinel
+    // 01: add the sentinel byte
     //
     block[block.length - inpLen - 1] = 0x01;
 
-    //
-    // as the block is already zeroed - there's no need to add PS (the >= 0 pad of 0)
-    //
+    // PS: since a new Uint8List is initialized with 0x00, PS is already zeroed
 
-    //
-    // add the hash of the encoding params.
+    // pHash: add the hash of the encoding params.
     //
     block = _arraycopy(defHash, 0, block, defHash.length, defHash.length);
 
@@ -251,9 +246,9 @@ class OAEPEncoding extends BaseAsymmetricBlockCipher {
 
     block = _arraycopy(seed, 0, block, 0, defHash.length);
 
-    // 9. Calculate _seedMask_ = MGF(maskDB, hLen)
+    // 9. Calculate _seedMask_ = MGF(maskedDB, hLen)
     //
-    // The _maskDB_ comes from [block], starting at offset _hLen_ to the end.
+    // The _maskedDB_ comes from [block], starting at offset _hLen_ to the end.
     // The result _seedMask_ is stored into [mask] (replacing the _dbMask_ which
     // is no longer needed).
 

--- a/tutorials/rsa.md
+++ b/tutorials/rsa.md
@@ -205,7 +205,7 @@ Pointy Castle implements PKCS #1 version 2.0 signature and
 verification. Specifically, it implements the _RSASSA-PKCS1-v1_5_
 signature scheme with appendix from section 8.1 of [RFC
 2437](https://tools.ietf.org/html/rfc2437#section-8.1): which defines
-how the digest algorithm identifier and digest value is encoded, and
+how the digest algorithm identifier and digest value are both encoded, and
 how that encoding is then signed using RSA.
 
 ### Implementation
@@ -463,6 +463,8 @@ p.init(false, PrivateKeyParameter<RSAPrivateKey>(myPrivate));
 
 ### Providing the data
 
+#### Using processBlock
+
 The data being encrypted/decrypted must be processed in blocks. Each
 input block is processed into an output block.
 
@@ -486,6 +488,18 @@ The `processBlock` method has five arguments:
 It returns the number of bytes written. Which is especially important
 when the last block is smaller than the maximum size. Always use the
 returned output size to know how much of the output is valid.
+
+#### Using process
+
+The `process` method can also be used instead of `processBlock`. It is
+simpler, because it creates and returns the output block. However, it
+requires the input to be no larger than _inputBlockSize_. And the
+_inputBlockSize_ depends on the bit-length of the key.
+
+If `process` is used, the program needs to ensure the size of the data
+and the bit-length of the key are both suitable.
+
+#### Decryption errors
 
 If the ciphertext cannot be decrypted, an `ArgumentError` is thrown.
 The message associated with the `ArgumentError` can be ignored, since


### PR DESCRIPTION
Bug fix for "RSA with OAEP fails nondeterministically" <https://github.com/PointyCastle/pointycastle/issues/177> issue.

This also solves the mystery of the redundant code from Bouncy Castle. Bouncy Castle's RSA decryption method returns a new array and the code then copied it into a new block. Pointy Castle creates a block and passes it into the RSA decryption method to populate, so no copying was/is required. But the Bouncy Castle code does more than just copying the bytes: it is also taking care of the situation when the decrypted bytes is shorter than expected.

Note: the encryption code was correct. Only the decryption code had a bug.