### PR TITLE
improved cbc performance

### DIFF
--- a/lib/block/modes/cbc.dart
+++ b/lib/block/modes/cbc.dart
@@ -76,7 +76,7 @@ class CBCBlockCipher extends BaseBlockCipher {
     int length = _underlyingCipher.processBlock(_cbcV, 0, out, outOff);
 
     // copy ciphertext to cbcV
-    _cbcV.setRange(0, blockSize, out.sublist(outOff));
+    _cbcV.setRange(0, blockSize, out.sublist(outOff, outOff + blockSize));
 
     return length;
   }
@@ -86,7 +86,7 @@ class CBCBlockCipher extends BaseBlockCipher {
       throw new ArgumentError("Input buffer too short");
     }
 
-    _cbcNextV.setRange(0, blockSize, inp.sublist(inpOff));
+    _cbcNextV.setRange(0, blockSize, inp.sublist(inpOff, inpOff + blockSize));
 
     int length = _underlyingCipher.processBlock(inp, inpOff, out, outOff);
 


### PR DESCRIPTION
The sublist commands only had their start argument set and at each iteration they take a sublist from the start all the way to the end. Now while that's trivial in small texts, it becomes a significant burden once the size and iteration goes up. for instance once the byte length goes from 400,000 to 800,000 the time takes goes from 2 seconds to 12 seconds and once we go above 1 million it just goes up even more exponentially.
You can try the following code snippet which yields these results to prove this point:
`Encrypted string, length: 400000, encrypted-length:400016, lasted  0:00:01.949904`
`Encrypted string, length: 800000, encrypted-length:800016, lasted  0:00:12.915183`
`Encrypted string, length: 1600000, encrypted-length:1600016, lasted  0:01:10.960904`
which becomes the following results following this fix:
`Encrypted string, length: 400000, encrypted-length:400016, lasted  0:00:00.051635`
`Encrypted string, length: 800000, encrypted-length:800016, lasted  0:00:00.042980`
`Encrypted string, length: 1600000, encrypted-length:1600016, lasted  0:00:00.084371`

On a further note, are you still looking for someone to take over the maintenance of this module?

here's the code that produces the log :

import 'package:encrypt/encrypt.dart';

var stopwatch = new Stopwatch()..start();
void log(message) {
  print('$message, lasted  ${stopwatch.elapsed}');
  stopwatch.reset();
}

void encrypt_and_decrypt(String str) {
  final iv = IV.fromBase16('95c4735086a5c909d66568592af98b28');
  final encrypter = Encrypter(AES(Key.fromBase16('2bb551c379dea568c4309323a29d9fdd3db9b4ec6b77951fa90359e82e8501ac'), mode: AESMode.cbc));
  log('Encrypter created');
  var encrypted = encrypter.encrypt(str, iv: iv);
  log('Encrypted string, length: ${str.length}, encrypted-length:${encrypted.bytes.length}');
  var decrypted = encrypter.decrypt(encrypted, iv:iv);
  log('Decrypted string, length: ${str.length}, decrypted-length:${decrypted.length}, equality: ${str==decrypted}');
}

void main(List<String> arguments) {
  encrypt_and_decrypt(List.filled(400 * 1000, 'a').join());
  encrypt_and_decrypt(List.filled(800 * 1000, 'a').join());
  encrypt_and_decrypt(List.filled(1600 * 1000, 'a').join());
}

